### PR TITLE
空行が挟まれてしまう事象の解決

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -111,6 +111,8 @@ sub vcl_deliver {
         set resp.http.X-aim-cache = "MISS";
     }
     if (req.http.X-aim-debug != "true") {
-        header.regsub(resp, "^(?i)X-aim.+", "");
+        # workaround to remove header without varnish plus...
+        header.regsub(resp, "^(?i)X-aim.+", "X-REMOVE-TARGET: 1");
+        unset resp.http.X-REMOVE-TARGET;
     }
 }


### PR DESCRIPTION
fixed: #18 

regsubだと置換なので空行が生成されていた模様。

varnish plusには[正規表現でheader removeできるvmod](https://docs.varnish-software.com/varnish-cache-plus/vmods/header/#remove) があるけど通常版にはないので、削除対象のヘッダたちを一回適当な同じヘッダ名に纏めてからunsetする。